### PR TITLE
Add test for get_configured_port

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,18 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+
+def load_engine_module():
+    engine_path = Path(__file__).resolve().parents[1] / "blueprint_engine" / "rootfs" / "usr" / "bin" / "engine.py"
+    spec = importlib.util.spec_from_file_location("engine", engine_path)
+    engine = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(engine)
+    return engine
+
+
+def test_get_configured_port_defaults_when_missing_options():
+    engine = load_engine_module()
+    with patch("builtins.open", side_effect=FileNotFoundError()):
+        port = engine.get_configured_port()
+    assert port == 8124


### PR DESCRIPTION
## Summary
- add pytest.ini for simple configuration
- create tests for engine.get_configured_port when options.json is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563db1cf0c8322b1782e7df7faa91f