### PR TITLE
Fix line breaks in README phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Home Assistant add-on that provides the processing engine for the HA 3D Blueprint system. This add-on performs the heavy mathematical calculations required for Radio Tomographic Imaging (RTI) to generate a 2D/3D model of your home's layout using Bluetooth RSSI values.
+A Home Assistant add-on that provides the processing engine for the HA&nbsp;3D&nbsp;Blueprint&nbsp;system. This add-on performs the heavy mathematical calculations required for Radio Tomographic Imaging (RTI) to generate a 2D/3D model of your home's layout using Bluetooth RSSI values.
 
 **This project is under active development and is considered experimental.**
 
@@ -10,7 +10,7 @@ A Home Assistant add-on that provides the processing engine for the HA 3D Bluepr
 
 ## Overview
 
-The Blueprint Engine is the computational backend for the HA 3D Blueprint system. It:
+The Blueprint Engine is the computational backend for the HA&nbsp;3D&nbsp;Blueprint&nbsp;system. It:
 
 - Collects and processes RSSI data from your Bluetooth sensors
 - Performs Radio Tomographic Imaging calculations


### PR DESCRIPTION
## Summary
- keep the words *HA 3D Blueprint system* together by using non-breaking spaces

## Testing
- `python -m py_compile blueprint_engine/rootfs/usr/bin/engine.py`

------
https://chatgpt.com/codex/tasks/task_e_68563daa10c08322839be10dcaaa8fc3